### PR TITLE
Test fix: set bean-discovery-mode to all for empty beans in Old security TCK

### DIFF
--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/autoapplysession/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/autoapplysession/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/basic/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/basic/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/customform/base/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/customform/base/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/customform/expression/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/customform/expression/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/form/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/form/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test1/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test1/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test2/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test2/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test3/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/rememberme/test3/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/sam/delegation/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/sam/delegation/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/sam/obtainbean/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/sam/obtainbean/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/cleansubject/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/cleansubject/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/secureresponse/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/secureresponse/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequest/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequest/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequestduringauthen/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequestduringauthen/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequestwithfilter/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/ham/workflow/validaterequestwithfilter/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/basic/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/basic/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/customhandler/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/customhandler/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/basic/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/basic/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/hashalgorithm/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/hashalgorithm/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/hashalgorithmparam/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/hashalgorithmparam/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidcallerquery/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidcallerquery/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invaliddatasource/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invaliddatasource/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidgroupsquery/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidgroupsquery/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidhashalgorithmparam/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidhashalgorithmparam/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidpriorityuseforexpr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/invalidpriorityuseforexpr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/multi/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/multi/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/notvalidated/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/notvalidated/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/priorityuseforexpr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/priorityuseforexpr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/priorityuseforexprbean/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/priorityuseforexprbean/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/useforgroup/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/useforgroup/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/useforvalidation/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/database/useforvalidation/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/idstorepermission/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/idstorepermission/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/basic/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/basic/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/binddn/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/binddn/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/groupmemberof/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/groupmemberof/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/groupmemberofnotexist/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/groupmemberofnotexist/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidbinddn/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidbinddn/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidbinddnpassword/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidbinddnpassword/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallerbasedn/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallerbasedn/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallernameattr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallernameattr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallersearchbase/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallersearchbase/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallersearchfilter/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidcallersearchfilter/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupmemberattr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupmemberattr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupnameattr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupnameattr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupsearchbase/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupsearchbase/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupsearchfilter/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidgroupsearchfilter/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidsearchscopeexpr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidsearchscopeexpr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidurl/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/invalidurl/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/notvalidated/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/notvalidated/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/priorityuseforexpr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/priorityuseforexpr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopebothonelevel/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopebothonelevel/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopebothsubtree/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopebothsubtree/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopecalleronelevelgroupsubtree/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopecalleronelevelgroupsubtree/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopecallersubtreegrouponelevel/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopecallersubtreegrouponelevel/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopeexpr/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/searchscopeexpr/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/useforgroup/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/useforgroup/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/useforvalidation/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/ldap/useforvalidation/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/multi/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/multi/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/multiauthz/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/multiauthz/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/noidstore/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/noidstore/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/useforgroup/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/useforgroup/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/useforvalidation/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/idstore/useforvalidation/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/authenticate/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/authenticate/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/callerdata/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/callerdata/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/ejb/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/ejb/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>

--- a/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/getprincipalsbytype/beans.xml
+++ b/tck/security-tck/src/com/sun/ts/tests/securityapi/securitycontext/getprincipalsbytype/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
+       bean-discovery-mode="all" version="3.0">
+</beans>


### PR DESCRIPTION
Fixed issue : https://github.com/eclipse-ee4j/jakartaee-tck/issues/927 

Change description: 
Set bean-discovery-mode="all" for all empty beans in old security tck tests that were migrated in https://github.com/jakartaee/security/pull/230. 

All tests pass in local with this change.

Thanks @arjantijms & @OndroMih for the hint.