### PR TITLE
Stabilized tomcat tests

### DIFF
--- a/tck/app-openid2/pom.xml
+++ b/tck/app-openid2/pom.xml
@@ -15,18 +15,18 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>org.eclipse.ee4j.security.tck</groupId>
         <artifactId>jakarta-security-tck</artifactId>
         <version>3.0.0-SNAPSHOT</version>
     </parent>
 
-	<artifactId>app-openid2</artifactId>
-	<packaging>war</packaging>
+    <artifactId>app-openid2</artifactId>
+    <packaging>war</packaging>
 
-	<properties>
+    <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
         <tomcat.version>9.0.63</tomcat.version>
@@ -35,7 +35,7 @@
         <finalName>openid-client</finalName>
     </properties>
 
-	<dependencies>
+    <dependencies>
         <dependency>
             <groupId>org.eclipse.ee4j.security.tck</groupId>
             <artifactId>common</artifactId>
@@ -49,7 +49,7 @@
             <type>pom</type>
         </dependency>
     </dependencies>
-	
+
     <build>
         <finalName>openid-client</finalName>
         <plugins>
@@ -180,39 +180,33 @@
             </plugin>
         </plugins>
         <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.apache.maven.plugins
-        								</groupId>
-        								<artifactId>
-        									maven-dependency-plugin
-        								</artifactId>
-        								<versionRange>
-        									[3.2.0,)
-        								</versionRange>
-        								<goals>
-        									<goal>copy</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[3.2.0,)</versionRange>
+                                        <goals>
+                                            <goal>copy</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
         </pluginManagement>
     </build>
 

--- a/tck/app-openid2/pom.xml
+++ b/tck/app-openid2/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
-        <tomcat.version>9.0.60</tomcat.version>
+        <tomcat.version>9.0.63</tomcat.version>
         <tomcat.dir>${tomcat.root}/apache-tomcat-${tomcat.version}</tomcat.dir>
         <tomcat.pidfile>${tomcat.dir}/pidfile</tomcat.pidfile>
         <finalName>openid-client</finalName>

--- a/tck/app-openid2/pom.xml
+++ b/tck/app-openid2/pom.xml
@@ -31,6 +31,7 @@
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
         <tomcat.version>9.0.60</tomcat.version>
         <tomcat.dir>${tomcat.root}/apache-tomcat-${tomcat.version}</tomcat.dir>
+        <tomcat.pidfile>${tomcat.dir}/pidfile</tomcat.pidfile>
         <finalName>openid-client</finalName>
     </properties>
 
@@ -69,7 +70,7 @@
                                 <artifactItem>
                                     <groupId>org.apache.tomcat</groupId>
                                     <artifactId>tomcat</artifactId>
-                                    <version>9.0.60</version>
+                                    <version>${tomcat.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
@@ -146,7 +147,9 @@
 
                                 <chmod dir="${tomcat.dir}/bin" perm="ugo+rx" includes="*" />
 
-                                <exec executable="${tomcat.dir}/bin/startup.sh" dir="${tomcat.dir}" />
+                                <exec executable="${tomcat.dir}/bin/startup.sh" dir="${tomcat.dir}" >
+                                    <env key="CATALINA_PID" value="${tomcat.pidfile}" />
+                                </exec>
 
                                 <!-- Give the server some time to settle down -->
                                 <sleep seconds="5" />
@@ -165,7 +168,11 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <!-- stop the server -->
-                                <exec executable="${tomcat.dir}/bin/shutdown.sh" dir="${tomcat.dir}" unless:set="tomcat.keeprunning" />
+                                <exec executable="${tomcat.dir}/bin/shutdown.sh" dir="${tomcat.dir}" unless:set="tomcat.keeprunning" >
+                                    <env key="CATALINA_PID" value="${tomcat.pidfile}" />
+                                    <arg value="30" />
+                                    <arg value="-force" />
+                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/tck/app-openid3/pom.xml
+++ b/tck/app-openid3/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
-        <tomcat.version>9.0.60</tomcat.version>
+        <tomcat.version>9.0.63</tomcat.version>
         <tomcat.dir>${tomcat.root}/apache-tomcat-${tomcat.version}</tomcat.dir>
         <tomcat.pidfile>${tomcat.dir}/pidfile</tomcat.pidfile>
         <finalName>openid-client</finalName>

--- a/tck/app-openid3/pom.xml
+++ b/tck/app-openid3/pom.xml
@@ -31,6 +31,7 @@
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
         <tomcat.version>9.0.60</tomcat.version>
         <tomcat.dir>${tomcat.root}/apache-tomcat-${tomcat.version}</tomcat.dir>
+        <tomcat.pidfile>${tomcat.dir}/pidfile</tomcat.pidfile>
         <finalName>openid-client</finalName>
     </properties>
 
@@ -69,7 +70,7 @@
                                 <artifactItem>
                                     <groupId>org.apache.tomcat</groupId>
                                     <artifactId>tomcat</artifactId>
-                                    <version>9.0.60</version>
+                                    <version>${tomcat.version}</version>
                                     <type>zip</type>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
@@ -146,7 +147,9 @@
 
                                 <chmod dir="${tomcat.dir}/bin" perm="ugo+rx" includes="*" />
 
-                                <exec executable="${tomcat.dir}/bin/startup.sh" dir="${tomcat.dir}" />
+                                <exec executable="${tomcat.dir}/bin/startup.sh" dir="${tomcat.dir}" >
+                                    <env key="CATALINA_PID" value="${tomcat.pidfile}" />
+                                </exec>
 
                                 <!-- Give the server some time to settle down -->
                                 <sleep seconds="5" />
@@ -165,7 +168,11 @@
                         <configuration>
                             <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                                 <!-- stop the server -->
-                                <exec executable="${tomcat.dir}/bin/shutdown.sh" dir="${tomcat.dir}" unless:set="tomcat.keeprunning" />
+                                <exec executable="${tomcat.dir}/bin/shutdown.sh" dir="${tomcat.dir}" unless:set="tomcat.keeprunning" >
+                                    <env key="CATALINA_PID" value="${tomcat.pidfile}" />
+                                    <arg value="30" />
+                                    <arg value="-force" />
+                                </exec>
                             </target>
                         </configuration>
                     </execution>

--- a/tck/app-openid3/pom.xml
+++ b/tck/app-openid3/pom.xml
@@ -15,18 +15,18 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
+    <parent>
         <groupId>org.eclipse.ee4j.security.tck</groupId>
         <artifactId>jakarta-security-tck</artifactId>
         <version>3.0.0-SNAPSHOT</version>
     </parent>
 
-	<artifactId>app-openid3</artifactId>
-	<packaging>war</packaging>
+    <artifactId>app-openid3</artifactId>
+    <packaging>war</packaging>
 
-	<properties>
+    <properties>
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <tomcat.root>${maven.multiModuleProjectDirectory}/target</tomcat.root>
         <tomcat.version>9.0.63</tomcat.version>
@@ -35,7 +35,7 @@
         <finalName>openid-client</finalName>
     </properties>
 
-	<dependencies>
+    <dependencies>
         <dependency>
             <groupId>org.eclipse.ee4j.security.tck</groupId>
             <artifactId>common</artifactId>
@@ -49,7 +49,7 @@
             <type>pom</type>
         </dependency>
     </dependencies>
-	
+
     <build>
         <finalName>openid-client</finalName>
         <plugins>
@@ -180,39 +180,33 @@
             </plugin>
         </plugins>
         <pluginManagement>
-        	<plugins>
-        		<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-        		<plugin>
-        			<groupId>org.eclipse.m2e</groupId>
-        			<artifactId>lifecycle-mapping</artifactId>
-        			<version>1.0.0</version>
-        			<configuration>
-        				<lifecycleMappingMetadata>
-        					<pluginExecutions>
-        						<pluginExecution>
-        							<pluginExecutionFilter>
-        								<groupId>
-        									org.apache.maven.plugins
-        								</groupId>
-        								<artifactId>
-        									maven-dependency-plugin
-        								</artifactId>
-        								<versionRange>
-        									[3.2.0,)
-        								</versionRange>
-        								<goals>
-        									<goal>copy</goal>
-        								</goals>
-        							</pluginExecutionFilter>
-        							<action>
-        								<ignore></ignore>
-        							</action>
-        						</pluginExecution>
-        					</pluginExecutions>
-        				</lifecycleMappingMetadata>
-        			</configuration>
-        		</plugin>
-        	</plugins>
+            <plugins>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-dependency-plugin</artifactId>
+                                        <versionRange>[3.2.0,)</versionRange>
+                                        <goals>
+                                            <goal>copy</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
         </pluginManagement>
     </build>
 


### PR DESCRIPTION
More stable startups of Tomcat immediately following shutdowns
    
* app-openid3 tests failed on some machines if executed right after app-openid2 because shutdown script for app-openid2 ended, but shutdown was still in progress while app-openid3 tried to start Tomcat again
* catalina.sh contains ways to stabilize that, so we can use them
* Updated Tomcat from 9.0.60 to 9.0.63
* whitespace cleanup