### PR TITLE
Remove the WildFly profiles from the TCK.

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -109,17 +109,11 @@
         
         <!-- Below Servers need to be updated to their Jakarta.* versions and currently don't work -->
         
-        
-        <!-- Note: WildFly 13 has EE Security (Soteria) included, but not activated -->
-        <wildfly.version>12.0.0.Final</wildfly.version>
-        
         <tomee.version>7.0.4</tomee.version>
         
         <!-- Note: Liberty 18.0.0.2+ has EE Security included -->
         <openliberty.version>18.0.0.1</openliberty.version>
-        
-        <wildfly-arquillian-container-managed.version>2.1.0.Final</wildfly-arquillian-container-managed.version>
-        
+
         <jacc-provider.version>0.3</jacc-provider.version>
     </properties>
 
@@ -674,74 +668,6 @@
                 </plugins>
             </build>
         </profile>
-        
-        
-       
-        <profile>
-            <id>wildfly</id>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.wildfly.arquillian</groupId>
-                    <artifactId>wildfly-arquillian-container-managed</artifactId>
-                    <version>${wildfly-arquillian-container-managed.version}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>unpack</id>
-                                <phase>process-test-classes</phase>
-                                <goals>
-                                    <goal>unpack</goal>
-                                </goals>
-                                <configuration>
-                                    <artifactItems>
-                                        <artifactItem>
-                                            <groupId>org.wildfly</groupId>
-                                            <artifactId>wildfly-dist</artifactId>
-                                            <version>${wildfly.version}</version>
-                                            <type>zip</type>
-                                            <overWrite>false</overWrite>
-                                            <outputDirectory>${project.build.directory}</outputDirectory>
-                                        </artifactItem>
-                                    </artifactItems>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.0.0-M5</version>
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <systemPropertyVariables>
-                                <finalName>${project.build.finalName}</finalName>
-                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                            </systemPropertyVariables>
-                            <environmentVariables>
-                                <JBOSS_HOME>${project.build.directory}/wildfly-${wildfly.version}</JBOSS_HOME>
-                            </environmentVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
 
         <profile>
             <id>tomee</id>
@@ -973,41 +899,6 @@
             </build>
         </profile>
 
-
-        <profile>
-            <id>wildfly-docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>io.fabric8</groupId>
-                        <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.39.1</version>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>wildfly</alias>
-                                    <name>tck-samples/${project.artifactId}:wildfly</name>
-                                    <build>
-                                        <maintainer>Ivar Grimstad (ivar.grimstad@gmail.com)</maintainer>
-                                        <from>jboss/wildfly:10.1.0.Final</from>
-                                        <assembly>
-                                            <basedir>/opt/jboss/wildfly/standalone/deployments/</basedir>
-                                            <descriptorRef>artifact</descriptorRef>
-                                        </assembly>
-                                    </build>
-                                    <run>
-                                        <ports>
-                                            <port>8088:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
         <profile>
             <id>payara-docker</id>
             <build>


### PR DESCRIPTION
These can be added back later once we have a compatible WildFly version
to reference.