### PR TITLE
change userinfoEndpoint in OpenIdProviderMetadata to optional

### DIFF
--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/openid/OpenIdProviderMetadata.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/openid/OpenIdProviderMetadata.java
@@ -56,7 +56,7 @@ public @interface OpenIdProviderMetadata {
     String tokenEndpoint() default "";
 
     /**
-     * Required. An OAuth 2.0 Protected Resource that returns Claims about the
+     * Optional. An OAuth 2.0 Protected Resource that returns Claims about the
      * authenticated End-User.
      *
      * @return URL for User Info.


### PR DESCRIPTION
hello,

i'm proposing to change the `userinfoEndpoint` in `OpenIdProviderMetadata` from `Required` to `Optional` in its javadoc.

i think this will make it more aligned with the authentication mechanism spec since:

1. it is not one of the required values under the `Metadata configuration` section.
> The following metadata values are required (since they are defined as required by the OpenID Specification):
> 
> Authorization endpoint
> 
> Token endpoint
> 
> JWKS URI
> 
> Issuer of the tokens
> 
> Supported Subject types
> 
> Supported Response types
> 
> Supported Id Token Signing Algorithms

https://github.com/jakartaee/security/blob/master/spec/src/main/asciidoc/authenticationMechanism.adoc#metadata-configuration

2. not all op's support the user info endpoint.
> An implementation may choose to not implement the call to the User Info Endpoint, in all cases or when a certain configuration value is set, since not all OpenID Connect Providers support this User Info Endpoint.

https://github.com/jakartaee/security/blob/master/spec/src/main/asciidoc/authenticationMechanism.adoc#caller-name-and-groups

Signed-off-by: Jimmy Wu <jimmywu0605@gmail.com>