### PR TITLE
update mock OP to use SignedJWT and return preferred_username in user info

### DIFF
--- a/tck/app-openid/src/main/java/ee/jakarta/tck/security/test/server/OidcProvider.java
+++ b/tck/app-openid/src/main/java/ee/jakarta/tck/security/test/server/OidcProvider.java
@@ -227,7 +227,8 @@ public class OidcProvider {
                        .add("email", "john.doe@acme.org")
                        .add("email_verified", true)
                        .add("gender", "male")
-                       .add("locale", "en");
+                       .add("locale", "en")
+                       .add("preferred_username", "johndoe");
 
             if (rolesInUserInfoEndpoint) {
                 JsonArrayBuilder groupsBuilder = Json.createArrayBuilder();

--- a/tck/app-openid/src/main/java/ee/jakarta/tck/security/test/server/OidcProvider.java
+++ b/tck/app-openid/src/main/java/ee/jakarta/tck/security/test/server/OidcProvider.java
@@ -45,12 +45,20 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.text.ParseException;
 import java.util.Date;
 import java.util.List;
 import java.util.logging.Logger;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.PlainJWT;
+import com.nimbusds.jwt.SignedJWT;
 
 import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
@@ -83,6 +91,7 @@ public class OidcProvider {
     private static final String BEARER_TYPE = "Bearer";
     private static final String AUTH_CODE_VALUE = "sample_auth_code";
     private static final String ACCESS_TOKEN_VALUE = "sample_access_token";
+    private static final String KID_VALUE = "sample_kid";
 
     private static String nonce;
 
@@ -143,7 +152,7 @@ public class OidcProvider {
     public Response tokenEndpoint(
             @FormParam(CLIENT_ID) String clientId, @FormParam(CLIENT_SECRET) String clientSecret,
             @FormParam(GRANT_TYPE) String grantType, @FormParam(CODE) String code,
-            @FormParam(REDIRECT_URI) String redirectUri) {
+            @FormParam(REDIRECT_URI) String redirectUri) throws JOSEException, IOException, ParseException {
 
         ResponseBuilder builder;
         JsonObjectBuilder jsonBuilder = Json.createObjectBuilder();
@@ -163,23 +172,32 @@ public class OidcProvider {
         } else {
 
             Date now = new Date();
-            JWTClaimsSet.Builder jstClaimsBuilder =
-                new JWTClaimsSet.Builder()
-                                .issuer("http://localhost:8080/openid-server/webresources/oidc-provider-demo")
-                                .subject(getSubject())
-                                .audience(List.of(CLIENT_ID_VALUE))
-                                .expirationTime(new Date(now.getTime() + 1000 * 60 * 10))
-                                .notBeforeTime(now)
-                                .issueTime(now)
-                                .jwtID(randomUUID().toString())
-                                .claim(NONCE, nonce);
 
+            JWK jwk = getJWKSet().getKeyByKeyId(KID_VALUE);
+            JWSSigner signer = new RSASSASigner(jwk.toRSAKey());
+
+            JWSHeader jwsHeader = new JWSHeader.Builder(JWSAlgorithm.RS256)
+                    .keyID(jwk.getKeyID())
+                    .build();
+
+            JWTClaimsSet.Builder jwtClaimsBuilder = new JWTClaimsSet.Builder()
+                    .issuer("http://localhost:8080/openid-server/webresources/oidc-provider-demo")
+                    .subject(getSubject())
+                    .audience(List.of(CLIENT_ID_VALUE))
+                    .expirationTime(new Date(now.getTime() + 1000 * 60 * 10))
+                    .notBeforeTime(now)
+                    .issueTime(now)
+                    .jwtID(randomUUID().toString())
+                    .claim(NONCE, nonce);
+            
             if (!rolesInUserInfoEndpoint) {
-                jstClaimsBuilder.claim(GROUPS, userGroups);
+                jwtClaimsBuilder.claim(GROUPS, userGroups);
             }
-            JWTClaimsSet jwtClaims = jstClaimsBuilder.build();
+            JWTClaimsSet jwtClaims = jwtClaimsBuilder.build();
 
-            PlainJWT idToken = new PlainJWT(jwtClaims);
+            SignedJWT idToken = new SignedJWT(jwsHeader, jwtClaims);
+            idToken.sign(signer);
+
             jsonBuilder.add(IDENTITY_TOKEN, idToken.serialize());
             jsonBuilder.add(ACCESS_TOKEN, ACCESS_TOKEN_VALUE);
             jsonBuilder.add(TOKEN_TYPE, BEARER_TYPE);
@@ -227,9 +245,33 @@ public class OidcProvider {
         return builder.entity(jsonBuilder.build().toString()).build();
     }
 
+    @GET
+    @Path("/certs")
+    @Produces(APPLICATION_JSON)
+    public Response jwksEndpoint() throws IOException, ParseException {
+        ResponseBuilder builder = Response.ok();
+
+        boolean publicKeysOnly = true;
+        JsonObjectBuilder jsonBuilder = Json.createObjectBuilder(getJWKSet().toJSONObject(publicKeysOnly));
+
+        return builder.entity(jsonBuilder.build().toString()).build();
+    }
+
     private String getSubject() {
         String subjectPrefix = "/subject-";
         return subject != null && subject.startsWith(subjectPrefix) ? subject.substring(subjectPrefix.length()) : "sample_subject";
+    }
+
+    private JWKSet getJWKSet() throws IOException, ParseException {
+        String jwks = "";
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        try (InputStream inputStream = classLoader.getResourceAsStream("jsonwebkeys.json")) {
+            jwks = new BufferedReader(new InputStreamReader(inputStream))
+                    .lines()
+                    .map(String::trim)
+                    .collect(joining());
+        }
+        return JWKSet.parse(jwks);
     }
 
 }

--- a/tck/app-openid/src/main/resources/jsonwebkeys.json
+++ b/tck/app-openid/src/main/resources/jsonwebkeys.json
@@ -1,0 +1,16 @@
+{
+  "keys": [
+    {
+      "p": "2nCKmx7reEK-4nqaZog_IZz6WiAl_21hdR95mg3a83XQ3uqf_VAMqUJwQV4cMVAkZQpTHNxH72xIWqcSAjeMRpQBZDLCaCfEpqFgkHfaA61yY0_LKwDMytkV0RXlNVrjpFpBeov7pDlYeTz9sqSbeswrIMJMOhDgy2jIm-j0maE",
+      "kty": "RSA",
+      "q": "uwooAgFE07dyrl7gUazxJrq9bn5KVbauVxA4euH7WwJ8ZLJy6G9F4I1RYupfsSg-X2G-M62g99kUibfmRpFRG_689k8MqHGDW4wVzY1OSSWxge7TrELpcTrSTKItg7SCG0JKPcEEJP1bGylAL4pzRJ4yc8n1UCXwxkMhDkwiAX8",
+      "d": "VWfawVBH5VeYELchycZsjM6VegueEApJhK0ITekNvYJXOvYYzDux5wwef8egoR4NozHdph9KGptDIShd_1uULbyLnXax1jmYROZpBrSiFcKgQnftvPDGljhbTOghmb5wsM3JsXPvV-HWCkGvCrOzsQsixcdJlnfgJN80IAbwwHljLvFWNV69D6FW1EI8F2A53ddMSMDcYzmoJq2ASoj7GPIbz_WrVKBatDhsjnfIrqO_9DT_FoDoh2jNm6nKCijBZHyyoSN9CCLQSjCOcLEHQIHza_-yWV9Qi83s3h5td3UvipnOcfyl8zLTf5BSD31WyKqQYLVblWjGjoBCvgSDQQ",
+      "e": "AQAB",
+      "kid": "sample_kid",
+      "qi": "lP7OFz-Q10artX9ovCB7f5gDM71jybbTs6x5OtkSI6w51rdD6hVH-E4A-DduG4n12U2Qeu3a0fradZj_k8j5bGK8dT6idwux2ScyXB8xvLHGbWlpomDH6tAv-7rSw3ds8VmHIf-xirD06mWgcQ-iOhfim_Rdsf6wTKHDo2kc11o",
+      "dp": "GccqNEAj3Z9S03tQeUUe3iKeUMB2e3w3AhFi0lFMQ2rl6Uia9NPbiqXyhWRLw24HvXzIbiF4w8Jtj3Uj5OsVPMb-mwp6crwustNch-_85G41j469FSgVAuM3deM1l2RQdPbJv2KBodG6pSQTdF-EkatCc606Paf8P0TwV6XYJ8E",
+      "dq": "Gs6k10y5QaLsU-OTQQGJeqSPG_QL0Wcia6YOgkY7UVr02zXcVEYGfN2kSYoP9wMulVsb-KotBPjfAbIS1hBj0KBdEuxXgxjp28gjI9fZ3ZACdf315p2cebcVhxhDb7oCX8fLfjhY0LhjQ2xRH783MCGAV6odd8RIUxIx_auZwB8",
+      "n": "n5jfyAVDsy0ziztP2wl4RJRfCzZyla-G_ww72RbO7gHjf2wNaznDAs96IHgQlwCCWT1jMUke2qiWOfCIlfjUGm3s55Xjwfq_e8g-_PBkZl-Bqyq19ADfW1DpRXcJSpQ9sI5UL8eYbwTh_hXksCvI_x9wAKhKyeZPcDmG9FX-WJf6153XLwN1kKzfOJluV2zrzsJNmeZLDbnC6x1PlqO2DmjnzR19uYJ9stgX4loj5-cxAkTFUcT7n8xrwf9a953PhQsJEMq5D4gdmgxcjgTNZPafpMrJSVg3gHmsLusIWKNMNIffmYNSdvMpyTqHw4grUt7-N5SD5B4_8tcnuVPX3w"
+    }
+  ]
+}

--- a/tck/app-openid/src/test/java/ee/jakarta/tck/security/test/OpenIdTestUtil.java
+++ b/tck/app-openid/src/test/java/ee/jakarta/tck/security/test/OpenIdTestUtil.java
@@ -46,6 +46,7 @@ public class OpenIdTestUtil {
                 .addClass(OidcProvider.class)
                 .addClass(ApplicationConfig.class)
                 .addAsResource("openid-configuration.json")
+                .addAsResource("jsonwebkeys.json")
                 .addAsWebInfResource("beans.xml");
 
         return war;


### PR DESCRIPTION
for #277 

- update OidcProvider to use SignedJWT
    - update the `/token` endpoint to use SignedJWT with RS256 instead of PlainJWT to comply with oidc spec
    - create the `/certs` endpoint to return the jwk set containing the jwk used to sign the id token in the `/token` endpoint

- additionally updated the `/userinfo` endpoint to also return a preferred_username, since the default callerNameClaim is preferred_username, but it is currently not sent in the access token, id token, nor userinfo (i put it into the user info, since that's where it's inserted in `app-openid2`)
