### PR TITLE
Fix ldap issues in TCK

### DIFF
--- a/tck/app-ldap/src/main/java/ee/jakarta/tck/security/test/Servlet.java
+++ b/tck/app-ldap/src/main/java/ee/jakarta/tck/security/test/Servlet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022, 2022 Contributors to the Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -34,7 +35,8 @@ import jakarta.servlet.http.HttpServletResponse;
 @LdapIdentityStoreDefinition(
     url = "#{'ldap://localhost:33389/'}", // usage of expression just for test
     callerBaseDn = "ou=caller,dc=jsr375,dc=net",
-    groupSearchBase = "ou=group,dc=jsr375,dc=net"
+    groupSearchBase = "ou=group,dc=jsr375,dc=net",
+    groupSearchFilter = "(&(member=%s)(objectclass=groupofnames))"
 )
 @DeclareRoles({ "foo", "bar", "kaz" })
 @WebServlet("/servlet")

--- a/tck/app-ldap3/src/main/resources/test.ldif
+++ b/tck/app-ldap3/src/main/resources/test.ldif
@@ -58,6 +58,11 @@ objectclass: top
 objectclass: groupOfNames
 cn: foo
 
+dn: cn=bar,ou=group,dc=jsr375,dc=net
+objectclass: top
+objectclass: groupOfNames
+cn: bar
+
 dn: cn=kaz,ou=group,dc=jsr375,dc=net
 objectclass: top
 objectclass: groupOfNames

--- a/tck/app-ldap3/src/main/resources/test.ldif
+++ b/tck/app-ldap3/src/main/resources/test.ldif
@@ -53,6 +53,16 @@ objectclass: top
 objectclass: organizationalUnit
 ou: group
 
+dn: cn=foo,ou=group,dc=jsr375,dc=net
+objectclass: top
+objectclass: groupOfNames
+cn: foo
+
+dn: cn=kaz,ou=group,dc=jsr375,dc=net
+objectclass: top
+objectclass: groupOfNames
+cn: kaz
+
 dn: ou=apps,dc=jsr375,dc=net
 objectclass: top
 objectclass: organizationalUnit


### PR DESCRIPTION
Fixes #275 Provide explicit group search filter according to challenge
Fixes #276  ldap-3 uses seeAlso (memberOf) in LDIF without defining those groups

Test depended on Soteria specific default.

Signed-off-by: Arjan Tijms <arjan.tijms@gmail.com>