### PR TITLE
Allow profile to specify https port for issue #277

### DIFF
--- a/tck/app-openid/src/test/java/ee/jakarta/tck/security/test/OpenIdTestUtil.java
+++ b/tck/app-openid/src/test/java/ee/jakarta/tck/security/test/OpenIdTestUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.resolver.api.maven.Maven;
@@ -54,6 +55,15 @@ public class OpenIdTestUtil {
                 .addAsLibraries(nimbus())
                 ;
 
+        if (Boolean.parseBoolean(System.getProperty("oidcProviderUsesHttps"))) {
+            String httpsPort = System.getProperty("oidcProviderHttpsPort");
+            System.out.println("Profile requested using HTTPS endpoints with port " + httpsPort + " for the server deployment.");
+
+            if (httpsPort != null && !httpsPort.isEmpty()) {
+                String content = "oidcProviderHttpsPort=" + httpsPort;
+                war.add(new StringAsset(content), "/oidcProviderHttpsPort.properties");
+            }
+        }
         return war;
     }
 


### PR DESCRIPTION
Signed-off-by: Teddy J. Torres <teddyjtorres@hotmail.com>

For issue #277

Allows a profile to specify that it needs to use an https port with the `oidcProviderUsesHttps` property and the port number with the `oidcProviderHttpsPort` property for the provider in the app-openid tests as follows,

```
                  <plugins>
                    <plugin>
                        <artifactId>maven-failsafe-plugin</artifactId>
                        <version>${maven.test.version}</version>
                        <configuration>
                            <systemPropertyVariables>
                                <wlp>${wlp.home}</wlp>
                                <webServerHost>localhost</webServerHost>
                                <webServerPort>9080</webServerPort>
                                <javax.net.ssl.trustStore>${wlp.home}/usr/servers/security-tck/resources/security/key.jks</javax.net.ssl.trustStore>
                                <javax.net.ssl.trustStorePassword>CHANGEIT</javax.net.ssl.trustStorePassword>
                                <oidcProviderUsesHttps>true</oidcProviderUsesHttps>
                                <oidcProviderHttpsPort>9443</oidcProviderHttpsPort>
                            </systemPropertyVariables>
                        </configuration>
                    </plugin>
                </plugins>
```

Establishing trust is accomplished by setting the `javax.net.ssl.trustStore` and `javax.net.ssl.trustStorePassword` properties. The trust store contains the server certificate.