### PR TITLE
Update keytool-maven-plugin to 1.7

### DIFF
--- a/tck/app-openid2/pom.xml
+++ b/tck/app-openid2/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0, which is available at
@@ -182,7 +182,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>keytool-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>pre-integration-test</phase>

--- a/tck/app-openid3/pom.xml
+++ b/tck/app-openid3/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+  Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
 
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License v. 2.0, which is available at
@@ -182,7 +182,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>keytool-maven-plugin</artifactId>
-                <version>1.6</version>
+                <version>1.7</version>
                 <executions>
                     <execution>
                         <phase>pre-integration-test</phase>


### PR DESCRIPTION
This is specifically important for the TCK to be able to run on the latest maven versions.