### PR TITLE
Add qualifiers to build-in authentication mechanism beans

### DIFF
--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,30 +17,75 @@
 
 package jakarta.security.enterprise.authentication.mechanism.http;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 
 /**
  * Annotation used to define a container authentication mechanism that implements
- * the HTTP basic access authentication protocol as defined by the Servlet spec (13.6.1)  
+ * the HTTP basic access authentication protocol as defined by the Servlet spec (13.6.1)
  * and make that implementation available as an enabled CDI bean.
  *
  */
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface BasicAuthenticationMechanismDefinition {
-    
+
     /**
      * Name of realm that will be sent via the <code>WWW-Authenticate</code> header.
      * <p>
      * Note that this realm name <b>does not</b> couple a named identity store
      * configuration to the authentication mechanism.
-     * 
+     *
      * @return Name of realm
      */
     String realmName() default "";
+
+    /**
+     * List of {@link Qualifier qualifier annotations}.
+     *
+     * <p>
+     * An {@link HttpAuthenticationMechanism} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code BasicAuthenticationMechanismDefinition}.</p>
+     *
+     * <p>
+     * The default value is {@code BasicAuthenticationMechanism}, indicating that
+     * this {@code BasicAuthenticationMechanismDefinition} produces
+     * bean instances of type {@link HttpAuthenticationMechanism} qualified by
+     * {@code BasicAuthenticationMechanism}.
+     *
+     * @return list of qualifiers.
+     * @since 4.0
+     */
+    Class<?>[] qualifiers() default { BasicAuthenticationMechanism.class };
+
+    @Qualifier
+    @Retention(RUNTIME)
+    @Target({FIELD, METHOD, TYPE, PARAMETER})
+    public static @interface BasicAuthenticationMechanism {
+
+        /**
+         * Supports inline instantiation of the {@link BasicAuthenticationMechanism} qualifier.
+         *
+         * @since 4.0
+         */
+        public static final class Literal extends AnnotationLiteral<BasicAuthenticationMechanism> implements BasicAuthenticationMechanism {
+            private static final long serialVersionUID = 1L;
+
+            /**
+             * Instance of the {@link BasicAuthenticationMechanism} qualifier.
+             */
+            public static final Literal INSTANCE = new Literal();
+        }
+
+    }
 }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/BasicAuthenticationMechanismDefinition.java
@@ -25,6 +25,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -37,6 +38,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RUNTIME)
 @Target(TYPE)
+@Repeatable(BasicAuthenticationMechanismDefinition.List.class)
 public @interface BasicAuthenticationMechanismDefinition {
 
     /**
@@ -67,6 +69,16 @@ public @interface BasicAuthenticationMechanismDefinition {
      * @since 4.0
      */
     Class<?>[] qualifiers() default { BasicAuthenticationMechanism.class };
+
+    /**
+     * Enables multiple <code>BasicAuthenticationMechanismDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        BasicAuthenticationMechanismDefinition[] value();
+    }
 
     @Qualifier
     @Retention(RUNTIME)

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
@@ -27,6 +27,7 @@ import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
 import jakarta.security.enterprise.SecurityContext;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -41,6 +42,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RUNTIME)
 @Target(TYPE)
+@Repeatable(CustomFormAuthenticationMechanismDefinition.List.class)
 public @interface CustomFormAuthenticationMechanismDefinition {
 
     @Nonbinding
@@ -64,6 +66,16 @@ public @interface CustomFormAuthenticationMechanismDefinition {
      * @since 4.0
      */
     Class<?>[] qualifiers() default { CustomFormAuthenticationMechanism.class };
+
+    /**
+     * Enables multiple <code>CustomFormAuthenticationMechanismDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        CustomFormAuthenticationMechanismDefinition[] value();
+    }
 
     @Qualifier
     @Retention(RUNTIME)

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,15 +17,18 @@
 
 package jakarta.security.enterprise.authentication.mechanism.http;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
+import jakarta.security.enterprise.SecurityContext;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import jakarta.enterprise.util.Nonbinding;
-
-import jakarta.security.enterprise.SecurityContext;
 
 /**
  * Annotation used to define a container authentication mechanism that implements
@@ -41,5 +45,45 @@ public @interface CustomFormAuthenticationMechanismDefinition {
 
     @Nonbinding
     LoginToContinue loginToContinue();
+
+    /**
+     * List of {@link Qualifier qualifier annotations}.
+     *
+     * <p>
+     * An {@link HttpAuthenticationMechanism} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code CustomFormAuthenticationMechanismDefinition}.</p>
+     *
+     * <p>
+     * The default value is {@code CustomFormAuthenticationMechanism}, indicating that
+     * this {@code CustomFormAuthenticationMechanismDefinition} produces
+     * bean instances of type {@link HttpAuthenticationMechanism} qualified by
+     * {@code CustomFormAuthenticationMechanism}.
+     *
+     * @return list of qualifiers.
+     * @since 4.0
+     */
+    Class<?>[] qualifiers() default { CustomFormAuthenticationMechanism.class };
+
+    @Qualifier
+    @Retention(RUNTIME)
+    @Target({FIELD, METHOD, TYPE, PARAMETER})
+    public static @interface CustomFormAuthenticationMechanism {
+
+        /**
+         * Supports inline instantiation of the {@link CustomFormAuthenticationMechanism} qualifier.
+         *
+         * @since 4.0
+         */
+        public static final class Literal extends AnnotationLiteral<CustomFormAuthenticationMechanism> implements CustomFormAuthenticationMechanism {
+            private static final long serialVersionUID = 1L;
+
+            /**
+             * Instance of the {@link CustomFormAuthenticationMechanisms} qualifier.
+             */
+            public static final Literal INSTANCE = new Literal();
+        }
+
+    }
 
 }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/CustomFormAuthenticationMechanismDefinition.java
@@ -79,7 +79,7 @@ public @interface CustomFormAuthenticationMechanismDefinition {
             private static final long serialVersionUID = 1L;
 
             /**
-             * Instance of the {@link CustomFormAuthenticationMechanisms} qualifier.
+             * Instance of the {@link CustomFormAuthenticationMechanism} qualifier.
              */
             public static final Literal INSTANCE = new Literal();
         }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -16,13 +17,17 @@
 
 package jakarta.security.enterprise.authentication.mechanism.http;
 
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-
-import jakarta.enterprise.util.Nonbinding;
 
 /**
  * Annotation used to define a container authentication mechanism that implements
@@ -36,5 +41,45 @@ public @interface FormAuthenticationMechanismDefinition {
 
     @Nonbinding
     LoginToContinue loginToContinue();
+
+    /**
+     * List of {@link Qualifier qualifier annotations}.
+     *
+     * <p>
+     * An {@link HttpAuthenticationMechanism} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code FormAuthenticationMechanismDefinition}.</p>
+     *
+     * <p>
+     * The default value is {@code FormAuthenticationMechanism}, indicating that
+     * this {@code FormAuthenticationMechanismDefinition} produces
+     * bean instances of type {@link HttpAuthenticationMechanism} qualified by
+     * {@code FormAuthenticationMechanism}.
+     *
+     * @return list of qualifiers.
+     * @since 4.0
+     */
+    Class<?>[] qualifiers() default { FormAuthenticationMechanism.class };
+
+    @Qualifier
+    @Retention(RUNTIME)
+    @Target({FIELD, METHOD, TYPE, PARAMETER})
+    public static @interface FormAuthenticationMechanism {
+
+        /**
+         * Supports inline instantiation of the {@link FormAuthenticationMechanism} qualifier.
+         *
+         * @since 4.0
+         */
+        public static final class Literal extends AnnotationLiteral<FormAuthenticationMechanism> implements FormAuthenticationMechanism {
+            private static final long serialVersionUID = 1L;
+
+            /**
+             * Instance of the {@link FormAuthenticationMechanisms} qualifier.
+             */
+            public static final Literal INSTANCE = new Literal();
+        }
+
+    }
 
 }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
@@ -75,7 +75,7 @@ public @interface FormAuthenticationMechanismDefinition {
             private static final long serialVersionUID = 1L;
 
             /**
-             * Instance of the {@link FormAuthenticationMechanisms} qualifier.
+             * Instance of the {@link FormAuthenticationMechanism} qualifier.
              */
             public static final Literal INSTANCE = new Literal();
         }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/FormAuthenticationMechanismDefinition.java
@@ -26,6 +26,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.enterprise.util.Nonbinding;
 import jakarta.inject.Qualifier;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -37,6 +38,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RUNTIME)
 @Target(TYPE)
+@Repeatable(FormAuthenticationMechanismDefinition.List.class)
 public @interface FormAuthenticationMechanismDefinition {
 
     @Nonbinding
@@ -60,6 +62,16 @@ public @interface FormAuthenticationMechanismDefinition {
      * @since 4.0
      */
     Class<?>[] qualifiers() default { FormAuthenticationMechanism.class };
+
+    /**
+     * Enables multiple <code>FormAuthenticationMechanismDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        FormAuthenticationMechanismDefinition[] value();
+    }
 
     @Qualifier
     @Retention(RUNTIME)

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/HttpAuthenticationMechanism.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/HttpAuthenticationMechanism.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2024 Contributors to Eclipse Foundation.
  * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -30,47 +31,53 @@ import jakarta.servlet.http.HttpServletResponse;
 /**
  * <code>HttpAuthenticationMechanism</code> is a mechanism for obtaining a caller's
  * credentials in some way, using the HTTP protocol where necessary.
- * 
+ *
  * <p>
  * This is used to help in securing Jakarta Servlet endpoints, including
- * endpoints that may be build on top of Jakarta Servlets like Jakarta RESTful Web Services endpoints and 
+ * endpoints that may be build on top of Jakarta Servlets like Jakarta RESTful Web Services endpoints and
  * Jakarta Faces views. It specifically <b>is not</b> used for endpoints such as remote Jakarta Enterprise Beans
  * or (Jakarta Messaging) message driven beans.
- * 
+ *
  * <p>
- * A <code>HttpAuthenticationMechanism</code> is essentially a Jakarta Servlet specific and CDI enabled version of
- * the {@link ServerAuthModule} that adheres to the Servlet Container Profile. See the Jakarta Authentication spec for 
+ * An <code>HttpAuthenticationMechanism</code> is essentially a Jakarta Servlet specific and CDI enabled version of
+ * the {@link ServerAuthModule} that adheres to the Servlet Container Profile. See the Jakarta Authentication spec for
  * further details on this.
- * 
+ *
  * <p>
  * Implementations of this class can notify the Jakarta Servlet container about a successful authentication by using the
  * {@link HttpMessageContext#notifyContainerAboutLogin(java.security.Principal, java.util.Set)} method.
- * 
+ *
  * <p>
  * Implementations are expected and encouraged to delegate the actual credential validation and/or retrieval of the
  * caller name with optional groups to an {@link IdentityStore}. This is however <b>not</b> required and implementations
  * can either do the validation checks for authentication completely autonomously, or delegate only certain aspects of
  * the process to the store (e.g. use the store only for retrieving the groups an authenticated user is in).
+ *
+ * <p>
+ * By default only one <code>HttpAuthenticationMechanism</code> can be active. This is enforced by the default implementation
+ * of the {@link HttpAuthenticationMechanismHandler}. If an application wants to use multiple <code>HttpAuthenticationMechanism</code>s,
+ * e.g. a Form mechanism for the UI section and Basic HTTP for a REST endpoint, a custom {@link HttpAuthenticationMechanismHandler} has
+ * to be provided. A future version of this specification may provide default behavior in this area.
  */
 public interface HttpAuthenticationMechanism {
 
     /**
      * Authenticate an HTTP request.
-     * 
+     *
      * <p>
-     * This method is called in response to an HTTP client request for a resource, and is always invoked 
+     * This method is called in response to an HTTP client request for a resource, and is always invoked
      * <strong>before</strong> any {@link Filter} or {@link HttpServlet}. Additionally this method is called
      * in response to {@link HttpServletRequest#authenticate(HttpServletResponse)}
-     * 
+     *
      * <p>
      * Note that by default this method is <strong>always</strong> called for every request, independent of whether
      * the request is to a protected or non-protected resource, or whether a caller was successfully authenticated
      * before within the same HTTP session or not.
-     * 
+     *
      * <p>
-     * A CDI/Interceptor spec interceptor can be used to prevent calls to this method if needed. 
+     * A CDI/Interceptor spec interceptor can be used to prevent calls to this method if needed.
      * See {@link AutoApplySession} and {@link RememberMe} for two examples.
-     * 
+     *
      * @param request contains the request the client has made
      * @param response contains the response that will be send to the client
      * @param httpMessageContext context for interacting with the container
@@ -78,18 +85,18 @@ public interface HttpAuthenticationMechanism {
      * @throws AuthenticationException when the processing failed
      */
     AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException;
-   
+
     /**
      * Secure the response, optionally.
-     * 
+     *
      * <p>
-     * This method is called to allow for any post processing to be done on the request, and is always invoked 
-     * <strong>after</strong> any {@link Filter} or {@link HttpServlet}. 
-     * 
+     * This method is called to allow for any post processing to be done on the request, and is always invoked
+     * <strong>after</strong> any {@link Filter} or {@link HttpServlet}.
+     *
      * <p>
      * Note that this method is only called when a (Servlet) resource has indeed been invoked, i.e. if a previous call
      * to <code>validateRequest</code> that was invoked before any {@link Filter} or {@link HttpServlet} returned SUCCESS.
-     *  
+     *
      * @param request contains the request the client has made
      * @param response contains the response that will be send to the client
      * @param httpMessageContext context for interacting with the container
@@ -99,16 +106,16 @@ public interface HttpAuthenticationMechanism {
     default AuthenticationStatus secureResponse(HttpServletRequest request, HttpServletResponse response, HttpMessageContext httpMessageContext) throws AuthenticationException {
         return SUCCESS;
     }
-    
+
     /**
      * Remove mechanism specific principals and credentials from the subject and any other state the mechanism
      * might have used.
-     * 
+     *
      * <p>
      * This method is called in response to {@link HttpServletRequest#logout()} and gives the authentication mechanism
      * the option to remove any state associated with an earlier established authenticated identity. For example, an
      * authentication mechanism that stores state within a cookie can send remove that cookie here.
-     * 
+     *
      * @param request contains the request the client has made
      * @param response contains the response that will be send to the client
      * @param httpMessageContext context for interacting with the container

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021, 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,22 +23,26 @@
  */
 package jakarta.security.enterprise.authentication.mechanism.http;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
-import java.lang.annotation.Retention;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import java.lang.annotation.Target;
-
-import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
-import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
-import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDefinition;
 import static jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant.CODE;
 import static jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant.EMAIL_SCOPE;
 import static jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant.OPENID_SCOPE;
 import static jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdConstant.PROFILE_SCOPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.ClaimsDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.DisplayType;
+import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDefinition;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
 import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
 
 
 
@@ -169,24 +173,24 @@ public @interface OpenIdAuthenticationMechanismDefinition {
     /**
      * The redirect URI (callback URI) to which the response will be sent by the OpenId
      * Connect Provider. This URI must be absolute and must exactly match one of the Redirection URI values
-     * for the Client pre-registered at the OpenID Provider. 
+     * for the Client pre-registered at the OpenID Provider.
      * <p>
-     * The value can be a Jakarta Expression Language 3.0 expression, which can contain 
-     * the implicit String variable baseURL. This variable contains the host and context path of the application 
-     * for which the OpenID Connect authentication mechanism is installed. This variable makes it easier to compose 
+     * The value can be a Jakarta Expression Language 3.0 expression, which can contain
+     * the implicit String variable baseURL. This variable contains the host and context path of the application
+     * for which the OpenID Connect authentication mechanism is installed. This variable makes it easier to compose
      * an absolute URL as required by the OpenID Connect specification.
-     * 
+     *
      * <p>
      * Examples:
      * <ul>
-     *  <li>{@code redirectURI = "${baseURL}/Callback"} - concatenates the `baseURL` variable and the "/Callback" string 
+     *  <li>{@code redirectURI = "${baseURL}/Callback"} - concatenates the `baseURL` variable and the "/Callback" string
      *    in a composite expression.
      *   </li>
-     *  <li>{@code redirectURI = "${baseURL += oidcConfig.redirectCallback}"} - concatenates the `baseURL` variable and the 
+     *  <li>{@code redirectURI = "${baseURL += oidcConfig.redirectCallback}"} - concatenates the `baseURL` variable and the
      *   `redirectCallback` property on bean `oidcConfig` in a single expression
      *  </li>
-     *  <li>{@code redirectURI = "${baseURL}#{oidcConfig.redirectCallback}"} - concatenates the `baseURL` variable and the 
-     *   `redirectCallback` property on bean `oidcConfig` in a composite expression. The `redirectCallback` property would 
+     *  <li>{@code redirectURI = "${baseURL}#{oidcConfig.redirectCallback}"} - concatenates the `baseURL` variable and the
+     *   `redirectCallback` property on bean `oidcConfig` in a composite expression. The `redirectCallback` property would
      *   be evaluated as a deferred expression during each request.
      *  </li>
      * </ul>
@@ -404,4 +408,44 @@ public @interface OpenIdAuthenticationMechanismDefinition {
      * @return
      */
     String tokenMinValidityExpression() default "";
+
+    /**
+     * List of {@link Qualifier qualifier annotations}.
+     *
+     * <p>
+     * An {@link HttpAuthenticationMechanism} injection point
+     * with these qualifier annotations injects a bean that is
+     * produced by this {@code OpenIdAuthenticationMechanismDefinition}.</p>
+     *
+     * <p>
+     * The default value is {@code OpenIdAuthenticationMechanism}, indicating that
+     * this {@code OpenIdAuthenticationMechanismDefinition} produces
+     * bean instances of type {@link HttpAuthenticationMechanism} qualified by
+     * {@code OpenIdAuthenticationMechanism}.
+     *
+     * @return list of qualifiers.
+     * @since 4.0
+     */
+    Class<?>[] qualifiers() default { OpenIdAuthenticationMechanism.class };
+
+    @Qualifier
+    @Retention(RUNTIME)
+    @Target({FIELD, METHOD, TYPE, PARAMETER})
+    public static @interface OpenIdAuthenticationMechanism {
+
+        /**
+         * Supports inline instantiation of the {@link OpenIdAuthenticationMechanism} qualifier.
+         *
+         * @since 4.0
+         */
+        public static final class Literal extends AnnotationLiteral<OpenIdAuthenticationMechanism> implements OpenIdAuthenticationMechanism {
+            private static final long serialVersionUID = 1L;
+
+            /**
+             * Instance of the {@link OpenIdAuthenticationMechanisms} qualifier.
+             */
+            public static final Literal INSTANCE = new Literal();
+        }
+
+    }
 }

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
@@ -41,6 +41,7 @@ import jakarta.security.enterprise.authentication.mechanism.http.openid.LogoutDe
 import jakarta.security.enterprise.authentication.mechanism.http.openid.OpenIdProviderMetadata;
 import jakarta.security.enterprise.authentication.mechanism.http.openid.PromptType;
 import jakarta.security.enterprise.identitystore.IdentityStoreHandler;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -115,6 +116,7 @@ import java.lang.annotation.Target;
  */
 @Target({TYPE, METHOD})
 @Retention(RUNTIME)
+@Repeatable(OpenIdAuthenticationMechanismDefinition.List.class)
 public @interface OpenIdAuthenticationMechanismDefinition {
 
     /**
@@ -427,6 +429,16 @@ public @interface OpenIdAuthenticationMechanismDefinition {
      * @since 4.0
      */
     Class<?>[] qualifiers() default { OpenIdAuthenticationMechanism.class };
+
+    /**
+     * Enables multiple <code>OpenIdAuthenticationMechanismDefinition</code>
+     * annotations on the same type.
+     */
+    @Retention(RUNTIME)
+    @Target(TYPE)
+    public @interface List {
+        OpenIdAuthenticationMechanismDefinition[] value();
+    }
 
     @Qualifier
     @Retention(RUNTIME)

--- a/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
+++ b/api/src/main/java/jakarta/security/enterprise/authentication/mechanism/http/OpenIdAuthenticationMechanismDefinition.java
@@ -442,7 +442,7 @@ public @interface OpenIdAuthenticationMechanismDefinition {
             private static final long serialVersionUID = 1L;
 
             /**
-             * Instance of the {@link OpenIdAuthenticationMechanisms} qualifier.
+             * Instance of the {@link OpenIdAuthenticationMechanism} qualifier.
              */
             public static final Literal INSTANCE = new Literal();
         }

--- a/tck/app-custom-authentication-mechanism-handler2/pom.xml
+++ b/tck/app-custom-authentication-mechanism-handler2/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.ee4j.security.tck</groupId>
+		<artifactId>jakarta-security-tck</artifactId>
+		<version>4.0.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>app-custom-authentication-mechanism-handler2</artifactId>
+	<packaging>war</packaging>
+
+	<properties>
+        <failOnMissingWebXml>false</failOnMissingWebXml>
+    </properties>
+
+	<dependencies>
+        <dependency>
+            <groupId>org.eclipse.ee4j.security.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+	<build>
+        <finalName>app-custom-authentication-mechanism-handler</finalName>
+	</build>
+</project>

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/BasicAuthenticationMechanism2.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/BasicAuthenticationMechanism2.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, TYPE, PARAMETER })
+public @interface BasicAuthenticationMechanism2 {
+
+    /**
+     * Supports inline instantiation of the {@link BasicAuthenticationMechanism2} qualifier.
+     *
+     * @since 4.0
+     */
+    public static final class Literal extends AnnotationLiteral<BasicAuthenticationMechanism2> implements BasicAuthenticationMechanism2 {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Instance of the {@link BasicAuthenticationMechanism2} qualifier.
+         */
+        public static final Literal INSTANCE = new Literal();
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/BasicAuthenticationMechanism3.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/BasicAuthenticationMechanism3.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.security.test;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD, TYPE, PARAMETER })
+public @interface BasicAuthenticationMechanism3 {
+
+    /**
+     * Supports inline instantiation of the {@link BasicAuthenticationMechanism3} qualifier.
+     *
+     * @since 4.0
+     */
+    public static final class Literal extends AnnotationLiteral<BasicAuthenticationMechanism3> implements BasicAuthenticationMechanism3 {
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Instance of the {@link BasicAuthenticationMechanism3} qualifier.
+         */
+        public static final Literal INSTANCE = new Literal();
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/CustomAuthenticationMechanismHandler.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/CustomAuthenticationMechanismHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package ee.jakarta.tck.security.test;
+
+import static jakarta.interceptor.Interceptor.Priority.APPLICATION;
+
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.AuthenticationException;
+import jakarta.security.enterprise.AuthenticationStatus;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition.BasicAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanism;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpMessageContext;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * This HttpAuthenticationMechanismHandler overrides the default provided one and delegates
+ * requests to three individual authentication mechanisms depending on the request path.
+ *
+ * <p>
+ * This tests asserts the ability to define multiple beans using
+ * a {@code ...Definition} annotation. It specifically asserts that
+ * those can come from a repeatable annotation ("realm2" and "realm3")
+ * and that those can be combined with one defined elsewhere ("realm1").
+ *
+ */
+@BasicAuthenticationMechanismDefinition(
+    realmName="realm2",
+    qualifiers = { BasicAuthenticationMechanism2.class}
+)
+
+@BasicAuthenticationMechanismDefinition(
+    realmName="realm3",
+    qualifiers = { BasicAuthenticationMechanism3.class}
+)
+
+@Alternative
+@Priority(APPLICATION)
+@ApplicationScoped
+public class CustomAuthenticationMechanismHandler implements HttpAuthenticationMechanismHandler {
+
+    @Inject
+    @BasicAuthenticationMechanism
+    HttpAuthenticationMechanism authenticationMechanism1;
+
+    @Inject
+    @BasicAuthenticationMechanism2
+    HttpAuthenticationMechanism authenticationMechanism2;
+
+    @Inject
+    @BasicAuthenticationMechanism3
+    HttpAuthenticationMechanism authenticationMechanism3;
+
+    @Override
+    public AuthenticationStatus validateRequest(HttpServletRequest request, HttpServletResponse response,
+            HttpMessageContext httpMessageContext) throws AuthenticationException {
+
+        if (getRequestRelativeURI(request).startsWith("/protectedServlet1")) {
+            return authenticationMechanism1.validateRequest(request, response, httpMessageContext);
+        }
+
+        if (getRequestRelativeURI(request).startsWith("/protectedServlet2")) {
+            return authenticationMechanism2.validateRequest(request, response, httpMessageContext);
+        }
+
+        return authenticationMechanism3.validateRequest(request, response, httpMessageContext);
+    }
+
+    public static String getRequestRelativeURI(HttpServletRequest request) {
+        return request.getRequestURI().substring(request.getContextPath().length());
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet1.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet1.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.annotation.security.DeclareRoles;
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.security.enterprise.authentication.mechanism.http.BasicAuthenticationMechanismDefinition;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Test Servlet that prints out the name of the authenticated caller and whether
+ * this caller is in any of the roles {foo, bar, kaz}
+ *
+ */
+@BasicAuthenticationMechanismDefinition(
+    realmName="realm1"
+)
+@WebServlet("/protectedServlet1")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "foo"))
+@DeclareRoles({"bar", "kaz"})
+public class ProtectedServlet1 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a servlet \n");
+
+        String webName = null;
+        if (request.getUserPrincipal() != null) {
+            webName = request.getUserPrincipal().getName();
+        }
+
+        response.getWriter().write("web username: " + webName + "\n");
+
+        response.getWriter().write("web user has role \"foo\": " + request.isUserInRole("foo") + "\n");
+        response.getWriter().write("web user has role \"bar\": " + request.isUserInRole("bar") + "\n");
+        response.getWriter().write("web user has role \"kaz\": " + request.isUserInRole("kaz") + "\n");
+
+        String contextName = null;
+        if (securityContext.getCallerPrincipal() != null) {
+            contextName = securityContext.getCallerPrincipal().getName();
+        }
+
+        response.getWriter().write("context username: " + contextName + "\n");
+
+        response.getWriter().write("context user has role \"foo\": " + securityContext.isCallerInRole("foo") + "\n");
+        response.getWriter().write("context user has role \"bar\": " + securityContext.isCallerInRole("bar") + "\n");
+        response.getWriter().write("context user has role \"kaz\": " + securityContext.isCallerInRole("kaz") + "\n");
+
+        response.getWriter().write("has access " + securityContext.hasAccessToWebResource("/servlets"));
+
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet2.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet2.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Test Servlet that prints out the name of the authenticated caller and whether
+ * this caller is in any of the roles {foo, bar, kaz}
+ *
+ */
+@WebServlet("/protectedServlet2")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "foo"))
+public class ProtectedServlet2 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a servlet \n");
+
+        String webName = null;
+        if (request.getUserPrincipal() != null) {
+            webName = request.getUserPrincipal().getName();
+        }
+
+        response.getWriter().write("web username: " + webName + "\n");
+
+        response.getWriter().write("web user has role \"foo\": " + request.isUserInRole("foo") + "\n");
+        response.getWriter().write("web user has role \"bar\": " + request.isUserInRole("bar") + "\n");
+        response.getWriter().write("web user has role \"kaz\": " + request.isUserInRole("kaz") + "\n");
+
+        String contextName = null;
+        if (securityContext.getCallerPrincipal() != null) {
+            contextName = securityContext.getCallerPrincipal().getName();
+        }
+
+        response.getWriter().write("context username: " + contextName + "\n");
+
+        response.getWriter().write("context user has role \"foo\": " + securityContext.isCallerInRole("foo") + "\n");
+        response.getWriter().write("context user has role \"bar\": " + securityContext.isCallerInRole("bar") + "\n");
+        response.getWriter().write("context user has role \"kaz\": " + securityContext.isCallerInRole("kaz") + "\n");
+
+        response.getWriter().write("has access " + securityContext.hasAccessToWebResource("/servlets"));
+
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet3.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/ProtectedServlet3.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import jakarta.inject.Inject;
+import jakarta.security.enterprise.SecurityContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.HttpConstraint;
+import jakarta.servlet.annotation.ServletSecurity;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Test Servlet that prints out the name of the authenticated caller and whether
+ * this caller is in any of the roles {foo, bar, kaz}
+ *
+ */
+@WebServlet("/protectedServlet3")
+@ServletSecurity(@HttpConstraint(rolesAllowed = "foo"))
+public class ProtectedServlet3 extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    @Inject
+    private SecurityContext securityContext;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        response.getWriter().write("This is a servlet \n");
+
+        String webName = null;
+        if (request.getUserPrincipal() != null) {
+            webName = request.getUserPrincipal().getName();
+        }
+
+        response.getWriter().write("web username: " + webName + "\n");
+
+        response.getWriter().write("web user has role \"foo\": " + request.isUserInRole("foo") + "\n");
+        response.getWriter().write("web user has role \"bar\": " + request.isUserInRole("bar") + "\n");
+        response.getWriter().write("web user has role \"kaz\": " + request.isUserInRole("kaz") + "\n");
+
+        String contextName = null;
+        if (securityContext.getCallerPrincipal() != null) {
+            contextName = securityContext.getCallerPrincipal().getName();
+        }
+
+        response.getWriter().write("context username: " + contextName + "\n");
+
+        response.getWriter().write("context user has role \"foo\": " + securityContext.isCallerInRole("foo") + "\n");
+        response.getWriter().write("context user has role \"bar\": " + securityContext.isCallerInRole("bar") + "\n");
+        response.getWriter().write("context user has role \"kaz\": " + securityContext.isCallerInRole("kaz") + "\n");
+
+        response.getWriter().write("has access " + securityContext.hasAccessToWebResource("/servlets"));
+
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/TestIdentityStore.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/java/ee/jakarta/tck/security/test/TestIdentityStore.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import static java.util.Arrays.asList;
+import static jakarta.security.enterprise.identitystore.CredentialValidationResult.INVALID_RESULT;
+
+import java.util.HashSet;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.security.enterprise.credential.UsernamePasswordCredential;
+import jakarta.security.enterprise.identitystore.CredentialValidationResult;
+import jakarta.security.enterprise.identitystore.IdentityStore;
+
+@ApplicationScoped
+public class TestIdentityStore implements IdentityStore {
+
+    public CredentialValidationResult validate(UsernamePasswordCredential usernamePasswordCredential) {
+
+        if (usernamePasswordCredential.compareTo("reza", "secret1")) {
+            return new CredentialValidationResult("reza", new HashSet<>(asList("foo", "bar")));
+        }
+
+        return INVALID_RESULT;
+    }
+
+}

--- a/tck/app-custom-authentication-mechanism-handler2/src/main/webapp/WEB-INF/beans.xml
+++ b/tck/app-custom-authentication-mechanism-handler2/src/main/webapp/WEB-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       bean-discovery-mode="all" version="4.0">
+</beans>

--- a/tck/app-custom-authentication-mechanism-handler2/src/test/java/ee/jakarta/tck/security/test/AppCustomAuthenticationMechanismHandler2IT.java
+++ b/tck/app-custom-authentication-mechanism-handler2/src/test/java/ee/jakarta/tck/security/test/AppCustomAuthenticationMechanismHandler2IT.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.security.test;
+
+import static ee.jakarta.tck.security.test.Assert.assertDefaultAuthenticated;
+import static ee.jakarta.tck.security.test.ShrinkWrap.mavenWar;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.gargoylesoftware.htmlunit.DefaultCredentialsProvider;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import jakarta.security.enterprise.authentication.mechanism.http.HttpAuthenticationMechanismHandler;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+/**
+ * This test asserts that an application provided {@link HttpAuthenticationMechanismHandler} can override
+ * the default one by allowing multiple authentication mechanisms to co-exists.
+ *
+ * <p>
+ * In this test, three instances of the build-in Basic HTTP authentication mechanism are used. The custom
+ * handler invokes each one depending on the request URI that was used.
+ */
+@RunWith(Arquillian.class)
+public class AppCustomAuthenticationMechanismHandler2IT extends ArquillianBase {
+
+    @Deployment(testable = false)
+    public static Archive<?> createDeployment() {
+        return mavenWar();
+    }
+
+    /**
+     * Test that for path {@code /protectedServlet1} in effect {@link TestAuthenticationMechanism1} is used.
+     */
+    @Test
+    public void testAuthenticated1() {
+        WebResponse response = responseFromServer("/protectedServlet1");
+
+        assertEquals(401, response.getStatusCode());
+
+        assertTrue(
+            "Response did not contain the \"WWW-Authenticate\" header, but should have",
+            response.getResponseHeaderValue("WWW-Authenticate") != null);
+
+
+        // Most important part of the test: check that we have the correct authentication mechanism instance used
+
+        assertTrue(
+            "Response did not contain \"realm1\" in the \"WWW-Authenticate\" header value, but should have",
+            response.getResponseHeaderValue("WWW-Authenticate").contains("realm1"));
+
+
+        // For completion, check that authentication mechanism also actually authenticates
+
+        DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
+        credentialsProvider.addCredentials("reza", "secret1");
+
+        getWebClient().setCredentialsProvider(credentialsProvider);
+
+        assertDefaultAuthenticated(
+            readFromServer("/protectedServlet1"));
+    }
+
+    /**
+     * Test that for path {@code /protectedServlet2} in effect {@link TestAuthenticationMechanism2} is used.
+     */
+    @Test
+    public void testAuthenticated2() {
+        WebResponse response = responseFromServer("/protectedServlet2");
+
+        assertEquals(401, response.getStatusCode());
+
+        assertTrue(
+            "Response did not contain the \"WWW-Authenticate\" header, but should have",
+            response.getResponseHeaderValue("WWW-Authenticate") != null);
+
+
+        // Most important part of the test: check that we have the correct authentication mechanism instance used
+
+        assertTrue(
+                "Response did not contain \"realm1\" in the \"WWW-Authenticate\" header value, but should have",
+                response.getResponseHeaderValue("WWW-Authenticate").contains("realm2"));
+
+
+        // For completion, check that authentication mechanism also actually authenticates
+
+        DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
+        credentialsProvider.addCredentials("reza", "secret1");
+
+        getWebClient().setCredentialsProvider(credentialsProvider);
+
+        assertDefaultAuthenticated(
+            readFromServer("/protectedServlet2"));
+    }
+
+    /**
+     * Test that for path {@code /protectedServlet3} in effect {@link TestAuthenticationMechanism3} is used.
+     */
+    @Test
+    public void testAuthenticated3() {
+        WebResponse response = responseFromServer("/protectedServlet3");
+
+        assertEquals(401, response.getStatusCode());
+
+        assertTrue(
+            "Response did not contain the \"WWW-Authenticate\" header, but should have",
+            response.getResponseHeaderValue("WWW-Authenticate") != null);
+
+
+        // Most important part of the test: check that we have the correct authentication mechanism instance used
+
+        assertTrue(
+                "Response did not contain \"realm3\" in the \"WWW-Authenticate\" header value, but should have",
+                response.getResponseHeaderValue("WWW-Authenticate").contains("realm3"));
+
+
+        // For completion, check that authentication mechanism also actually authenticates
+
+        DefaultCredentialsProvider credentialsProvider = new DefaultCredentialsProvider();
+        credentialsProvider.addCredentials("reza", "secret1");
+
+        getWebClient().setCredentialsProvider(credentialsProvider);
+
+        assertDefaultAuthenticated(
+            readFromServer("/protectedServlet3"));
+    }
+
+}


### PR DESCRIPTION
Fixes #311 

This will add qualifiers to the build-in authentication mechanisms, with the ability for users to provide their own.