### PR TITLE
On branch edburns-msft-jea-339-absorb-assertions-from-cdi-integration Built-in beans from CDI integration spec.

### DIFF
--- a/spec/src/main/asciidoc/concepts.adoc
+++ b/spec/src/main/asciidoc/concepts.adoc
@@ -76,3 +76,12 @@ Attributes on these annotations, as well as on the annotations referenced from t
 For more information, see the package javadoc for the jakarta.security.enterprise package.
  
 Jakarta Expression Language, version 5.0 [https://jakarta.ee/specifications/expression-language/5.0/[EL50]] is a Jakarta EE specification.
+
+==== Built-in beans, not otherwise specified
+
+Several other sections in this specification mention built-in beans. This section details the required built-in beans that are not specified elsewhere.
+
+A Jakarta EE or embeddable EJB container must provide the following built-in beans, all of which have qualifier `@Default`:
+
+* a bean with bean type `jakarta.transaction.UserTransaction`, allowing injection of a reference to the JTA `UserTransaction`, and
+* a bean with bean type `java.security.Principal`, allowing injection of a `Principal` representing the current caller identity.

--- a/spec/src/main/asciidoc/concepts.adoc
+++ b/spec/src/main/asciidoc/concepts.adoc
@@ -83,5 +83,4 @@ Several other sections in this specification mention built-in beans. This sectio
 
 A Jakarta EE or embeddable EJB container must provide the following built-in beans, all of which have qualifier `@Default`:
 
-* a bean with bean type `jakarta.transaction.UserTransaction`, allowing injection of a reference to the JTA `UserTransaction`, and
 * a bean with bean type `java.security.Principal`, allowing injection of a `Principal` representing the current caller identity.


### PR DESCRIPTION
modified:   spec/src/main/asciidoc/concepts.adoc

Addresses https://github.com/jakartaee/platform/pull/855#pullrequestreview-1931388280