### PR TITLE
Fixed missing password to the GF truststore + Updated Failsafe

### DIFF
--- a/tck/app-openid2/pom.xml
+++ b/tck/app-openid2/pom.xml
@@ -135,14 +135,14 @@
                         <configuration>
                             <target>
                                 <echo level="info">Replacing in ${tomcat.dir}</echo>
-                                
+
                                 <replace token="http://localhost:8080" value="https://localhost:8443" dir="${tomcat.dir}/webapps/openid-connect-server-webapp/WEB-INF" summary="yes">
                                     <include name="server-config.xml" />
                                 </replace>
                                 <replace token="http://localhost/" value="http://localhost:8080/openid-client/Callback" dir="${tomcat.dir}/webapps/openid-connect-server-webapp/WEB-INF/classes/db/hsql" summary="yes">
                                     <include name="clients.sql" />
                                 </replace>
-                                
+
                                 <copy file="server.xml" todir="${tomcat.dir}/conf"/>
                                 <copy file="localhost-rsa.jks" todir="${tomcat.dir}/conf"/>
 
@@ -185,6 +185,7 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
+                        <id>import-tomcat-cert</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>importCertificate</goal>
@@ -192,31 +193,30 @@
                         <configuration>
                             <file>tomcat.cert</file>
                             <alias>tomcat</alias>
-                            <keystore>${glassfish.root}/glassfish7/glassfish/domains/domain1/config/cacerts.p12</keystore>
-                            <storepass>changeit</storepass>
-                            <keypass>changeit</keypass>
+                            <keystore>${trustStore.path}</keystore>
+                            <storepass>${trustStore.password}</storepass>
                             <noprompt>true</noprompt>
                             <trustcacerts>true</trustcacerts>
                             <verbose>true</verbose>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>delete-tomcat-cert</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>deleteAlias</goal>
+                        </goals>
+                        <configuration>
+                            <alias>tomcat</alias>
+                            <keystore>${trustStore.path}</keystore>
+                            <storepass>${trustStore.password}</storepass>
+                            <verbose>true</verbose>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemPropertyVariables>
-                        <javax.net.ssl.trustStore>${glassfish.root}/glassfish7/glassfish/domains/domain1/config/cacerts.p12</javax.net.ssl.trustStore>
-                        
-                        <glassfish.systemProperties>
-                            javax.net.debug=ssl,trustmanager,ssl:handshake
-                        </glassfish.systemProperties>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/tck/app-openid3/pom.xml
+++ b/tck/app-openid3/pom.xml
@@ -135,14 +135,14 @@
                         <configuration>
                             <target>
                                 <echo level="info">Replacing in ${tomcat.dir}</echo>
-                                
+
                                 <replace token="http://localhost:8080" value="https://localhost:8443" dir="${tomcat.dir}/webapps/openid-connect-server-webapp/WEB-INF" summary="yes">
                                     <include name="server-config.xml" />
                                 </replace>
                                 <replace token="http://localhost/" value="http://localhost:8080/openid-client/Callback" dir="${tomcat.dir}/webapps/openid-connect-server-webapp/WEB-INF/classes/db/hsql" summary="yes">
                                     <include name="clients.sql" />
                                 </replace>
-                                
+
                                 <copy file="server.xml" todir="${tomcat.dir}/conf"/>
                                 <copy file="localhost-rsa.jks" todir="${tomcat.dir}/conf"/>
 
@@ -185,6 +185,7 @@
                 <version>1.7</version>
                 <executions>
                     <execution>
+                        <id>import-tomcat-cert</id>
                         <phase>pre-integration-test</phase>
                         <goals>
                             <goal>importCertificate</goal>
@@ -192,27 +193,30 @@
                         <configuration>
                             <file>tomcat.cert</file>
                             <alias>tomcat</alias>
-                            <keystore>${glassfish.root}/glassfish7/glassfish/domains/domain1/config/cacerts.jks</keystore>
-                            <storepass>changeit</storepass>
-                            <keypass>changeit</keypass>
+                            <keystore>${trustStore.path}</keystore>
+                            <storepass>${trustStore.password}</storepass>
                             <noprompt>true</noprompt>
                             <trustcacerts>true</trustcacerts>
                             <verbose>true</verbose>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>delete-tomcat-cert</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>deleteAlias</goal>
+                        </goals>
+                        <configuration>
+                            <alias>tomcat</alias>
+                            <keystore>${trustStore.path}</keystore>
+                            <storepass>${trustStore.password}</storepass>
+                            <verbose>true</verbose>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <javax.net.ssl.trustStore>${glassfish.root}/glassfish7/glassfish/domains/domain1/config/cacerts.jks</javax.net.ssl.trustStore>
-                    </systemProperties>
-                </configuration>
-            </plugin>
         </plugins>
-        
+
         <pluginManagement>
             <plugins>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -298,7 +298,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>3.5.3</version>
                 </plugin>
 
                 <plugin>
@@ -371,7 +371,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.0.0-M7</version>
+                <version>3.5.3</version>
                 <executions>
                     <execution>
                         <phase>post-integration-test</phase>
@@ -386,20 +386,20 @@
             </plugin>
         </plugins>
     </build>
-    
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>3.0.0-M6</version>
-				<configuration>
-					<skipSurefireReport>${skipSurefireReport}</skipSurefireReport>
-					<aggregate>true</aggregate>
-				</configuration>
-			</plugin>
-		</plugins>
-	</reporting>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <skipSurefireReport>${skipSurefireReport}</skipSurefireReport>
+                    <aggregate>true</aggregate>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <profiles>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -413,10 +413,16 @@
             </activation>
 
             <properties>
-                <glassfish.version>7.0.0-M10</glassfish.version>
+                <glassfish.version>7.0.25</glassfish.version>
                 <glassfish.port>8080</glassfish.port>
                 <glassfish.suspend>false</glassfish.suspend>
+                <glassfish.dirName>glassfish7</glassfish.dirName>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
+                <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
+                <glassfish.javax.net.debug></glassfish.javax.net.debug>
+                <trustStore.suffix>jks</trustStore.suffix>
+                <trustStore.path>${glassfish.home}/glassfish/domains/domain1/config/cacerts.${trustStore.suffix}</trustStore.path>
+                <trustStore.password>changeit</trustStore.password>
             </properties>
 
             <dependencies>
@@ -473,10 +479,10 @@
                                 <configuration>
                                     <skip>${skipITs}</skip>
                                     <target>
-                                        <echo level="info">Replacing in ${glassfish.root}</echo>
+                                        <echo level="info">Replacing in ${glassfish.home}</echo>
                                         <replace token="8080"
                                             value="${glassfish.port}"
-                                            dir="${glassfish.root}/glassfish7/glassfish/domains/domain1/config/"
+                                            dir="${glassfish.home}/glassfish/domains/domain1/config/"
                                             summary="yes">
                                             <include name="domain.xml" />
                                         </replace>
@@ -489,9 +495,14 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <systemProperties>
-                                <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
-                            </systemProperties>
+                            <systemPropertyVariables>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
+                                <javax.net.ssl.trustStore>${trustStore.path}</javax.net.ssl.trustStore>
+                                <javax.net.ssl.trustStorePassword>${trustStore.password}</javax.net.ssl.trustStorePassword>
+                                <glassfish.systemProperties>
+                                    javax.net.debug=${glassfish.javax.net.debug}
+                                </glassfish.systemProperties>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -503,11 +514,16 @@
             <id>glassfish-ci-managed-update</id>
 
             <properties>
-                <glassfish.version>7.0.0-M10</glassfish.version>
+                <glassfish.version>7.0.25</glassfish.version>
                 <glassfish.port>8080</glassfish.port>
                 <glassfish.suspend>false</glassfish.suspend>
+                <glassfish.dirName>glassfish7</glassfish.dirName>
                 <glassfish.root>${maven.multiModuleProjectDirectory}/target</glassfish.root>
-                
+                <glassfish.home>${glassfish.root}/${glassfish.dirName}</glassfish.home>
+                <trustStore.suffix>jks</trustStore.suffix>
+                <trustStore.path>${glassfish.home}/glassfish/domains/domain1/config/cacerts.${trustStore.suffix}</trustStore.path>
+                <trustStore.password>changeit</trustStore.password>
+
                 <soteria.version>3.0.0</soteria.version>
                 <weld-decorator.version>3.0.0</weld-decorator.version>
             </properties>
@@ -563,7 +579,7 @@
                                             <version>${security-api.version}</version>
                                             <type>jar</type>
                                             <overWrite>true</overWrite>
-                                            <outputDirectory>${glassfish.root}/glassfish7/glassfish/modules</outputDirectory>
+                                            <outputDirectory>${glassfish.home}/glassfish/modules</outputDirectory>
                                             <destFileName>jakarta.security.enterprise-api.jar</destFileName>
                                         </artifactItem>
                                         <artifactItem>
@@ -572,7 +588,7 @@
                                             <version>${soteria.version}</version>
                                             <type>jar</type>
                                             <overWrite>true</overWrite>
-                                            <outputDirectory>${glassfish.root}/glassfish7/glassfish/modules</outputDirectory>
+                                            <outputDirectory>${glassfish.home}/glassfish/modules</outputDirectory>
                                             <destFileName>jakarta.security.enterprise.jar</destFileName>
                                         </artifactItem>
                                         <artifactItem>
@@ -581,7 +597,7 @@
                                             <version>${weld-decorator.version}</version>
                                             <type>jar</type>
                                             <overWrite>true</overWrite>
-                                            <outputDirectory>${glassfish.root}/glassfish7/glassfish/modules</outputDirectory>
+                                            <outputDirectory>${glassfish.home}/glassfish/modules</outputDirectory>
                                             <destFileName>soteria.spi.bean.decorator.weld.jar</destFileName>
                                         </artifactItem>
                                     </artifactItems>
@@ -593,9 +609,11 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <systemProperties>
-                                <glassfish.home>${glassfish.root}/glassfish7</glassfish.home>
-                            </systemProperties>
+                            <systemPropertyVariables>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
+                                <javax.net.ssl.trustStore>${trustStore.path}</javax.net.ssl.trustStore>
+                                <javax.net.ssl.trustStorePassword>${trustStore.password}</javax.net.ssl.trustStorePassword>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
* Failsafe 
  - original milestone versions did not print stacktraces, just one line.
  - Surefire report plugin should keep the same version
* The fix fixes the test side of the communication, GlassFish resolves same problem here: https://github.com/eclipse-ee4j/glassfish/pull/25662 . GF 7.0.x sets the password to system properties, that is the reason why it always worked.

```
mvn clean install -f tck -Dglassfish.version=7.1.0-SNAPSHOT -DtrustStore.suffix=p12 -Dglassfish.javax.net.debug=all
```